### PR TITLE
fix: Botón de show reporte, Fallo al añadir ubicación en blanco y Mantener estado seleccionado #150

### DIFF
--- a/product/templates/products/create.html
+++ b/product/templates/products/create.html
@@ -137,7 +137,7 @@
         var x = document.getElementById("id_nombreComercio").value;
         var y = id_ubicaciones.value;
         var z = document.getElementById("id_foto").files[0];
-        if (x == "" && y == "" && !z){
+        if (x.trim() == "" && y == "" && !z){
             alert("Seleccione una foto y elija o cree una ubicación")
             return false;
         }

--- a/product/templates/products/createMap.html
+++ b/product/templates/products/createMap.html
@@ -80,7 +80,7 @@
     function validateUbicaciones() {
         var x = document.getElementById("id_nombreComercio").value;
         var y = id_ubicaciones.value;
-        if (x == "" && y == "" ){
+        if (x.trim() == "" && y == "" ){
             alert("Elija o cree una ubicación")
             return false;
         }

--- a/product/templates/products/list.html
+++ b/product/templates/products/list.html
@@ -94,10 +94,10 @@
                             <div style="padding-bottom: 10px;font-weight: bold;">Estado:</div>
 
                                 <span style="margin-left: 35px;"><span class="form-check-input">
-                                    <input form="estado-form" type="radio" id="estado" name="estado" value="aceptado"> Aceptado
+                                    <input form="estado-form" type="radio" id="estadoA" name="estado" value="aceptado"> Aceptado
                                 </span></span><br><div style="height:1em"></div>
                                 <span style="margin-left: 35px;"><span class="form-check-input">
-                                    <input form="estado-form" type="radio" id="estado" name="estado" value="pendiente"> Pendiente
+                                    <input form="estado-form" type="radio" id="estadoP" name="estado" value="pendiente"> Pendiente
                                 </span></span>
                                 <br>
                             <div style="height:1em"></div>
@@ -217,6 +217,15 @@
                 var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
                 results = regex.exec(location.search);
                 return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+            }
+        </script>
+        <!-- Script checkbox estado -->
+        <script type="text/javascript">
+            let href = location.href;
+            if(href.includes("aceptado")){ 
+                document.getElementById("estadoA").checked = true;
+            }else if (href.includes("pendiente")){
+                document.getElementById("estadoP").checked = true;
             }
         </script>
 

--- a/product/templates/reports/list.html
+++ b/product/templates/reports/list.html
@@ -52,7 +52,7 @@
 
                                     </div>
                                     <div class="modal-footer justify-content-center">
-                                        <a href="/product/show/{{report.producto.id}}"> <button class="btn btn-primary"
+                                        <a href="/product/review/{{report.producto.id}}"> <button class="btn btn-primary"
                                                 style="margin-top: 0px !important;">Ver producto</button></a>
                                     </div>
                                     <div class="modal-footer justify-content-center">


### PR DESCRIPTION
Los problemas que se han solventado son:
-Que el botón de show reporte, te lleve a la vista de reporte del producto.
-Añadir ubicación con el nombre vacío (espacio en blanco) falla.
-Cuando se filtra por estado, no se queda marcado el filtro.